### PR TITLE
enable gzip compression

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -8,6 +8,7 @@ var express = require('express'),
 var app = express();
 
 app.use(express.logger());
+app.use(express.compress());
 app.use(express['static'](__dirname + '/..'));
 
 app.configure('production', function(){


### PR DESCRIPTION
A small change to enable gzip compression on the server.

I've deployed a version with the amendment to Heroku, you can see it here - https://lit-beach-8985.herokuapp.com/. You can see a comparison between the two by looking at the response headers of the following requests.

Original:

https://jsonp.nodejitsu.com/?callback=myCallback&url=http://jsonview.com/example.json

Amended:

https://lit-beach-8985.herokuapp.com/?callback=myCallback&url=http://jsonview.com/example.json
