### PR TITLE
fix for requesting sites behind CloudFlare

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - "0.10"
+  - "0.12"
 notifications:
   webhooks:
     urls:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - "0.10"
-  - "0.12"
 notifications:
   webhooks:
     urls:

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "optionalDependencies": {},
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">=0.10.0 <0.14.0"
   },
   "scripts": {
     "start": "node --expose-gc server/run.js",

--- a/server/cloudflare.js
+++ b/server/cloudflare.js
@@ -1,0 +1,10 @@
+/* jshint node:true */
+var u = require('underscore');
+
+
+// remove all CloudFlare headers, since they block requests that are already proxied (through the jsonp.afeld.me)
+module.exports.filterHeaders = function(headers) {
+  return u.omit(headers, function(val, header) {
+    return /^cf-/.test(header);
+  });
+};

--- a/server/proxy-request.js
+++ b/server/proxy-request.js
@@ -22,6 +22,7 @@ var passThroughHeaders = function(incomingHeaders) {
 
   externalReqHeaders = cloudflare.filterHeaders(externalReqHeaders);
   externalReqHeaders.accept = 'application/json';
+  externalReqHeaders.connection = 'close';
 
   return externalReqHeaders;
 };

--- a/server/proxy-request.js
+++ b/server/proxy-request.js
@@ -3,6 +3,7 @@
 var requestp = require('./requestp');
 var u = require('underscore');
 var JSON3 = require('json3');
+var cloudflare = require('./cloudflare');
 
 
 var shouldGarbageCollect = function() {
@@ -11,8 +12,17 @@ var shouldGarbageCollect = function() {
 
 var passThroughHeaders = function(incomingHeaders) {
   // remove those that node should generate
-  var externalReqHeaders = u.omit(incomingHeaders, 'accept-encoding', 'connection', 'cookie', 'host', 'user-agent');
+  var externalReqHeaders = u.omit(incomingHeaders,
+    'accept-encoding',
+    'connection',
+    'cookie',
+    'host',
+    'user-agent'
+  );
+
+  externalReqHeaders = cloudflare.filterHeaders(externalReqHeaders);
   externalReqHeaders.accept = 'application/json';
+
   return externalReqHeaders;
 };
 

--- a/server/router.js
+++ b/server/router.js
@@ -4,6 +4,7 @@ var u = require('underscore');
 var JSON3 = require('json3');
 var snippets = require('./snippets');
 var proxy = require('./proxy-request');
+var cloudflare = require('./cloudflare');
 
 var router = express.Router();
 
@@ -19,7 +20,14 @@ var serveLandingPage = function(req, res) {
 
 var passBackHeaders = function(incomingHeaders) {
   // remove those that node should generate
-  return u.omit(incomingHeaders, 'content-length', 'connection', 'server', 'x-frame-options');
+  var resultHeaders = u.omit(incomingHeaders,
+    'connection',
+    'content-length',
+    'server',
+    'x-frame-options'
+  );
+
+  return cloudflare.filterHeaders(resultHeaders);
 };
 
 var errorToJson = function(error) {

--- a/test/server_test.js
+++ b/test/server_test.js
@@ -69,7 +69,36 @@ describe('app', function(){
     });
   });
 
-  it('should exclude particular headers from the server', function(done){
+  it("shouldn't send particular headers to the destination", function(done){
+    var destApp = express();
+    destApp.get('/', function(req, res){
+      // echo the headers
+      res.json(req.headers);
+    });
+    var server = http.createServer(destApp);
+    server.listen(8001, function(){
+
+      supertest(app)
+        .get('/')
+        .set('CF-Foo', 'abc123')
+        .query({url: 'http://localhost:8001'})
+        .end(function(err, res) {
+          expect(res.body).to.eql({
+            accept: 'application/json',
+            connection: 'keep-alive',
+            host: 'localhost:8001'
+          });
+
+          server.on('close', function(){
+            done(err);
+          });
+          server.close();
+        });
+
+    });
+  });
+
+  it('should exclude particular headers from the destination', function(done){
     var json = JSON.stringify({ message: 'test' });
 
     var destApp = express();
@@ -77,6 +106,7 @@ describe('app', function(){
       res.set({
         'Connection': 'blabla',
         'Server': 'CERN/3.0 libwww/2.17',
+        'CF-Foo': 'abc123',
         'X-Frame-Options': 'SAMEORIGIN',
         // an arbitrary header, just to ensure they're getting passed
         'X-Foo': 'bar'
@@ -96,6 +126,7 @@ describe('app', function(){
         .expect(json, function(err, res){
           if (!err){
             expect(res.headers['x-foo']).to.be('bar'); // double-check
+            expect(res.headers['cf-foo']).to.be(undefined);
             expect(res.headers.server).to.be(undefined);
             expect(res.headers['x-frame-options']).to.be(undefined);
           }

--- a/test/server_test.js
+++ b/test/server_test.js
@@ -85,7 +85,7 @@ describe('app', function(){
         .end(function(err, res) {
           expect(res.body).to.eql({
             accept: 'application/json',
-            connection: 'keep-alive',
+            connection: 'close',
             host: 'localhost:8001'
           });
 


### PR DESCRIPTION
CloudFlare on the destination site was seeing its own headers added on the jsonp.afeld.me passthrough – they are now removed.